### PR TITLE
Update read_jdx.R file

### DIFF
--- a/R/read_jdx.R
+++ b/R/read_jdx.R
@@ -3,7 +3,7 @@
 #'
 #' Import JCAMP-DX files to hyperSpec objects.  Uses the `readJDX` function in package `readJDX`.
 #' See the vignettes there for much more information.
-#' 
+#'
 #' @param file Character. The file name to import. See "file" argument in [readJDX::readJDX()].
 #'
 #' @param SOFC Logical. "Stop on Failed Check". See "SOFC" argument in [readJDX::readJDX()].
@@ -16,7 +16,8 @@
 #'  \item The second element is a hyperSpec object
 #' }
 #'
-#' @author Sang Truong 
+#' @author Sang Truong
+#' Maintainer: Sang Truong <sttruong@stanford.edu>
 #'
 #' @export
 #' @concept io
@@ -26,6 +27,7 @@
 #' @import hySpc.testthat
 #' @import readJDX
 #' @importFrom dplyr bind_rows
+#' @importFrom utils maintainer packageDescription
 #'
 #' @examples
 #'
@@ -33,7 +35,7 @@
 #' spc <- read_jdx(sbo)[[2]] # grab the data
 #' plot(spc)
 #' head(sbo[[1]], n = 40) # metadata is available too
-#'
+
 read_jdx <- function(file = stop("filename is needed"), SOFC = TRUE, debug = 0) {
 
   list_jdx <- readJDX(file = file, SOFC = SOFC, debug = debug)
@@ -54,13 +56,34 @@ read_jdx <- function(file = stop("filename is needed"), SOFC = TRUE, debug = 0) 
     spc@label$filename <- file
     return(list(metadata = list_jdx[[2]], hyperSpec = spc))
   }
+  else {
+    stop(
+      "read_jdx() so far can only return a list of 4 or 5 elements from readJDX::readJDX.",
+      " Please file an enhancement request at", packageDescription("hyperSpc.read.jdx")$BugReports,
+      " with your file as an example or contact the maintainer (",
+      maintainer("hySpc.read.jdx"), ")."
+    )
+  }
 }
 
 hySpc.testthat::test(read_jdx) <- function() {
   context("read_jdx")
   sbo <- system.file("extdata", "SBO.jdx", package = "readJDX")
-  test_that("Can import JCAMP-DX file", {
+  pcrf <- system.file("extdata", "PCRF.jdx", package = "readJDX")
+  isasspc <- system.file("extdata", "isasspc1.dx", package = "readJDX")
+
+  test_that("JCAMP-DX file can be imported", {
     expect_silent(spc <- read_jdx(sbo)[[2]])
     expect_equal(dim(spc), c(nrow = 1L, ncol = length(colnames(spc)), nwl = 1868L))
+  })
+
+  test_that("readJDX::readJDX only return a list of 4 or 5 elements", {
+    expect_equal(length(readJDX(sbo)), 4)
+
+    expect_equal(length(readJDX(pcrf)), 5)
+
+    expect_error(hyperSpc.read.jdx::read_jdx(isasspc))
+
+    expect_warning(readJDX(isasspc))
   })
 }


### PR DESCRIPTION
- Add unittest
- Add stop if readJDX::readJDX() function return a list has length other than 4 or 5
- Resolve #17 